### PR TITLE
Parse csv with regex

### DIFF
--- a/src/csv.erl
+++ b/src/csv.erl
@@ -150,7 +150,7 @@ process_chunk([Match | Matches], Chunk,
                   process_chunk(Matches, Chunk, State,
                                 [], [NewLine | Acc], Pos+Len);
         FieldBy -> process_chunk(Matches, Chunk, State,
-                                 [Csv | LineAcc], Acc, Pos+Len)
+                                 [Csv2 | LineAcc], Acc, Pos+Len)
     end.
 %%
 

--- a/src/csv.erl
+++ b/src/csv.erl
@@ -115,7 +115,7 @@ decode(Chunk, #csv{recbuf = RecBuf, regex = Regex} = State)
  when is_binary(Chunk) ->
     NewChunk = iolist_to_binary([RecBuf, Chunk]),
     Match = re:run(NewChunk, Regex, [global, {capture, all, index}]),
-    {ok, {_Csv, _NewState} = Result} = process_match(Match, State, Chunk),
+    {ok, {_Csv, _NewState} = Result} = process_match(Match, State, NewChunk),
     Result.
 
 -spec process_match({match, [binary:part()]} | nomatch, #csv{}, binary()) ->

--- a/test/csv_tests.erl
+++ b/test/csv_tests.erl
@@ -1,0 +1,47 @@
+-module(csv_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+quotes_and_newlines_test() ->
+    % given
+    Expected = [[<<"a">>, <<"b">>],
+                [<<"1">>, <<"ha \"ha\" ha">>],
+                [<<"3">>, <<"4">>]],
+    CsvBin = <<"a,b\n1,\"ha \n\"\"ha\"\" \nha\"\n3,4\n">>,
+    % when
+    {Csv, _} = csv:decode(CsvBin, csv:new()),
+    % then
+    ?assertEqual(Expected, Csv).
+
+
+escaped_quotes_test() ->
+    % given
+    Expected = [[<<"a">>, <<"b">>],
+                [<<"1">>, <<"ha \"ha\" ha">>],
+                [<<"3">>, <<"4">>]],
+    CsvBin = <<"a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n">>,
+    % when
+    {Csv, _} = csv:decode(CsvBin, csv:new()),
+    % then
+    ?assertEqual(Expected, Csv).
+
+utf8_test() ->
+    % given
+    Expected = [[<<"a">>,<<13371/utf8>>,<<"c">>],
+                [<<"1">>,<<"2">>,<<"3">>],
+                [<<"4">>,<<"5">>,<<676/utf8>>]],
+    CsvBin = <<97,44,227,144,187,44,99,10,49,44,50,44,51,10,52,44,53,44,202,164,10>>,
+    % when
+    {Csv, _} = csv:decode(CsvBin, csv:new()),
+    % then
+    ?assertEqual(Expected, Csv).
+
+json_test() ->
+    % given
+    Expected = [[<<"key">>, <<"val">>],
+                [<<"1">>, <<"{\"type\": \"Point\",\"coordinates\": [102.0, 0.5]}">>]],
+    CsvBin = <<"key,val\n1,\"{\"\"type\"\": \"\"Point\"\",\"\"coordinates\"\": [102.0, 0.5]}\"\n">>,
+    % when
+    {Csv, _} = csv:decode(CsvBin, csv:new()),
+    % then
+    ?assertEqual(Expected, Csv).


### PR DESCRIPTION
This PR changes the way CVS are decoded. Basically we are now depending on regex, while parsing CSV chunks.
It matches valid CSV fields, including delimiters and quotes like (`"blabla",` or `last_item\n`). It also supports quote escaping, so `"my name is ""Name"""` is also properly recognised. 
To support lazy evaluation (`stdio.erl` module) we are parsing matches only to the last one, which ends with new line character `\n`. So if we have chunk like `<<"a,b,c,d\na,b,c">>` it will parse until `d` is reached and leave the rest in buffer.
I also added some test cases to prove this works.